### PR TITLE
Use base52 for hash encoding on production of CSS classes

### DIFF
--- a/config/postcss.js
+++ b/config/postcss.js
@@ -24,7 +24,7 @@ const compileOptions = {
 			extension: 'pcss',
 			plugins: [
 				require( 'postcss-modules' )( {
-					generateScopedName: 'production' === process.env.NODE_ENV ? '[contenthash:base64:5]' : 'Ⓜ[name]__[local]__[contenthash:base64:2]',
+					generateScopedName: 'production' === process.env.NODE_ENV ? '[contenthash:base52:5]' : 'Ⓜ[name]__[local]__[contenthash:base64:2]',
 					Loader: FileSystemLoader.default,
 					globalModulePaths: [
 						new RegExp( '.*?' + config.theme_path.replace( /\//g, '\\\\' ) + 'pcss', 'i' ),


### PR DESCRIPTION
I was able to remove the `_` at the beginning of the class, creating our own hash using the same logic that `css-module` is using, `generateScopedName`: https://github.com/madyankin/postcss-modules#usage allow a function that we can use to render our own hash. 

I used the `loader-util` lib to generate it, this is the library that postcss-modules uses:

Example:
```js
const getHashDigest = require('loader-utils').getHashDigest;
const randomBytes = require('crypto').randomBytes;

generateScopedName: 'production' === process.env.NODE_ENV ? function() {
                        // Same as [contenthash:base64:5]
						return getHashDigest( randomBytes(256),
							'xxhash64', // default
							'base64',
							5 );
					} : 'Ⓜ[name]__[local]__[contenthash:base64:2]',
```

The code above generates the hash using the same string hash `[contenthash:base64:5]` but without the `_`, I linked the local package to test the changes on theshack project, but I realized that some classes are broken and this is the reason why:

If you look at the front-end.min.css that was generated using the code above, you will notice that all the classes that start with a number are scape with `\`, that because in the CSS file a class name can't start with a number, that's the reason why all the classes that you saw created only with `[contenthash:base64:5]` has an `_` at the beginning, that's to avoid errors, for example, `2zuMh` was converted to `_2zuMh`.

So, without a string at the beginning, all the classes with a number will be broken.

This page shows a good example of the selectors: https://www.geeksforgeeks.org/which-characters-are-valid-in-css-class-names-selectors/#:~:text=A%20valid%20name%20should%20start,by%20a%20number%20is%20valid.

Anyway, I realized that we can use `[contenthash:base52:5]` that only include alphanumeric and the generated classes going to be always a length of `5`,
